### PR TITLE
Replace wp-cli based cron with a curl based cron

### DIFF
--- a/pkg/controller/wordpress/internal/sync/cron.go
+++ b/pkg/controller/wordpress/internal/sync/cron.go
@@ -34,8 +34,7 @@ import (
 	"github.com/presslabs/wordpress-operator/pkg/internal/wordpress"
 )
 
-// CurlImage represents a small docker image that contains only curl, used to ping wp-cron pool
-const CurlImage = "buildpack-deps:stretch-curl"
+const curlImage = "buildpack-deps:stretch-curl"
 
 // NewWPCronSyncer returns a new sync.Interface for reconciling wp-cron CronJob
 func NewWPCronSyncer(wp *wordpress.Wordpress, c client.Client, scheme *runtime.Scheme) syncer.Interface {
@@ -83,7 +82,7 @@ func NewWPCronSyncer(wp *wordpress.Wordpress, c client.Client, scheme *runtime.S
 		template.Spec.Containers = []corev1.Container{
 			{
 				Name:  "curl",
-				Image: CurlImage,
+				Image: curlImage,
 				Args:  cmd,
 			},
 		}


### PR DESCRIPTION
Instead of using wp-cli to run the `cron`, use curl. In this way, we'll avoid spawning a new web container that needs to clone the entire codebase and also it will block the code PVC, if we down-scale the deployment.

Fixes #10, #9 

#### Tests
- `git checkout replace-cron-with-curl`
- `make run`
- deploy a new website (you can use the chart from `https://github.com/presslabs/wordpress-chart` or https://github.com/presslabs/wordpress-operator/blob/master/config/samples/wordpress_v1alpha1_wordpress.yaml)
- new cron containers **should** spawn every minute
```
vtemian-site-wp-cron-1551969480-hxxh7                   0/1     Completed          0          4s
```
- `kubectl logs <wp-cron-container>` should display 
```
HTTP/1.1 200 OK
Server: openresty
Date: Thu, 07 Mar 2019 14:41:06 GMT
Content-Type: text/html; charset=UTF-8
Connection: keep-alive
X-Powered-By: PHP/7.2.15
```
