### PR TITLE
Start rclone containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ spec:
             secretKeyRef:
               name: mysite
               key: google_application_credentials.json
+        - name: GOOGLE_PROJECT_ID
+          value: development
     # persistentVolumeClaim: {}
     # hostPath: {}
     # emptyDir: {}

--- a/pkg/controller/wordpress/wordpress_controller_test.go
+++ b/pkg/controller/wordpress/wordpress_controller_test.go
@@ -171,5 +171,6 @@ var _ = Describe("Wordpress controller", func() {
 			Eventually(requests, timeout).Should(Receive(Equal(expectedRequest)))
 			Eventually(func() error { return c.Get(context.TODO(), key, obj) }, timeout).Should(Succeed())
 		}, entries...)
+
 	})
 })

--- a/pkg/internal/wordpress/defaults.go
+++ b/pkg/internal/wordpress/defaults.go
@@ -17,7 +17,7 @@ limitations under the License.
 package wordpress
 
 const (
-	defaultTag           = "5.0.3-php72-r62"
+	defaultTag           = "5.0.3-php72-r74"
 	defaultImage         = "quay.io/presslabs/wordpress-runtime"
 	codeSrcMountPath     = "/var/run/presslabs.org/code/src"
 	defaultCodeMountPath = "/var/www/site/web/wp-content"

--- a/pkg/internal/wordpress/defaults.go
+++ b/pkg/internal/wordpress/defaults.go
@@ -17,7 +17,7 @@ limitations under the License.
 package wordpress
 
 const (
-	defaultTag           = "5.0.3-php72-r12"
+	defaultTag           = "5.0.3-php72-r62"
 	defaultImage         = "quay.io/presslabs/wordpress-runtime"
 	codeSrcMountPath     = "/var/run/presslabs.org/code/src"
 	defaultCodeMountPath = "/var/www/site/web/wp-content"

--- a/pkg/internal/wordpress/pod_template.go
+++ b/pkg/internal/wordpress/pod_template.go
@@ -319,6 +319,17 @@ func (wp *Wordpress) getMediaContainers() []corev1.Container {
 		}
 	}
 
+	// ftp
+	// rclone serve ftp --vfs-cache-max-age 30s --vfs-cache-mde full --vfs-cache-poll-interval 0 --poll-interval 0
+	// We want to cache writes and reads on the FTP server since thumbnails are going to be generated and also
+	// because Wordpress is doing a directory listing in order to display the media gallery.
+	// We also set the poll interval to zero to avoid any unnecessary requests to the remote buckets.
+
+	// http
+	// rclone serve http --dir-cache-time 0
+	// HTTP is used only to read media and the caching will be done in another layer. Also, because some upstreams are
+	// eventually consistent, we don't want to cache stale responses.
+
 	return []corev1.Container{
 		{
 			Name:  "rclone-ftp",

--- a/pkg/internal/wordpress/pod_template.go
+++ b/pkg/internal/wordpress/pod_template.go
@@ -72,18 +72,18 @@ var (
 		"AWS_SECRET_ACCESS_KEY": "AWS_SECRET_ACCESS_KEY",
 		"AWS_CONFIG_FILE":       "AWS_CONFIG_FILE",
 		"ENDPOINT":              "S3_ENDPOINT",
-		"REGION":              	 "AWS_REGION",
-		"ACL":              	 "AWS_ACL",
+		"REGION":                "AWS_REGION",
+		"ACL":                   "AWS_ACL",
 		"STORAGE_CLASS":         "AWS_STORAGE_CLASS",
 	}
 	gcsEnvVars = map[string]string{
 		"GOOGLE_CREDENTIALS":             "GCS_SERVICE_ACCOUNT_JSON_KEY",
 		"GOOGLE_APPLICATION_CREDENTIALS": "GCS_SERVICE_ACCOUNT_JSON_KEY",
-		"GOOGLE_PROJECT_ID":			  "GCS_PROJECT_ID",
-		"GOOGLE_OBJECT_ACL": 			  "GCS_OBJECT_ACL",
-		"GOOGLE_BUCKET_ACL": 			  "GCS_BUCKET_ACL",
-		"GOOGLE_STORAGE_LOCATION": 		  "GCS_LOCATION",
-		"GOOGLE_STORAGE_CLASS": 		  "GCS_STORAGE_CLASS",
+		"GOOGLE_PROJECT_ID":              "GCS_PROJECT_ID",
+		"GOOGLE_OBJECT_ACL":              "GCS_OBJECT_ACL",
+		"GOOGLE_BUCKET_ACL":              "GCS_BUCKET_ACL",
+		"GOOGLE_STORAGE_LOCATION":        "GCS_LOCATION",
+		"GOOGLE_STORAGE_CLASS":           "GCS_STORAGE_CLASS",
 	}
 )
 
@@ -284,7 +284,7 @@ func (wp *Wordpress) gitCloneContainer() corev1.Container {
 
 func (wp *Wordpress) getMediaContainers() []corev1.Container {
 	if wp.Spec.MediaVolumeSpec == nil ||
-		(wp.Spec.MediaVolumeSpec.S3VolumeSource == nil && wp.Spec.MediaVolumeSpec.GCSVolumeSource == nil){
+		(wp.Spec.MediaVolumeSpec.S3VolumeSource == nil && wp.Spec.MediaVolumeSpec.GCSVolumeSource == nil) {
 		return []corev1.Container{}
 	}
 
@@ -315,21 +315,21 @@ func (wp *Wordpress) getMediaContainers() []corev1.Container {
 		}
 	}
 
-	return []corev1.Container {
+	return []corev1.Container{
 		{
-			Name:    "rclone-ftp",
-			Image:   rcloneImage,
-			Args:    []string{"serve", "ftp", "--vfs-cache-max-age", "30s", "--vfs-cache-mode", "full",
+			Name:  "rclone-ftp",
+			Image: rcloneImage,
+			Args: []string{"serve", "ftp", "--vfs-cache-max-age", "30s", "--vfs-cache-mode", "full",
 				"--vfs-cache-poll-interval", "0", "--poll-interval", "0", stream, "--config=/etc/rclone.conf",
 				fmt.Sprintf("--addr=0.0.0.0:%s", mediaFTPPort)},
-			Env:     env,
+			Env: env,
 		},
 		{
-			Name:    "rclone-http",
-			Image:   rcloneImage,
-			Args:    []string{"serve", "http", "--dir-cache-time", "0", stream, "--config=/etc/rclone.conf",
+			Name:  "rclone-http",
+			Image: rcloneImage,
+			Args: []string{"serve", "http", "--dir-cache-time", "0", stream, "--config=/etc/rclone.conf",
 				fmt.Sprintf("--addr=0.0.0.0:%s", mediaHTTPPort)},
-			Env:     env,
+			Env: env,
 		},
 	}
 }

--- a/pkg/internal/wordpress/pod_template_suite_test.go
+++ b/pkg/internal/wordpress/pod_template_suite_test.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2019 Pressinfra SRL.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wordpress
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+)
+
+func TestPodTemplate(t *testing.T) {
+	logf.SetLogger(logf.ZapLoggerTo(GinkgoWriter, true))
+	RegisterFailHandler(Fail)
+	RunSpecsWithDefaultAndCustomReporters(t, "Pod Template Suite", []Reporter{envtest.NewlineReporter{}})
+}

--- a/pkg/internal/wordpress/pod_template_test.go
+++ b/pkg/internal/wordpress/pod_template_test.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2019 Pressinfra SRL.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wordpress
+
+import (
+	"fmt"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	"math/rand"
+
+	wordpressv1alpha1 "github.com/presslabs/wordpress-operator/pkg/apis/wordpress/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("Web pod spec", func() {
+	var (
+		wp *Wordpress
+	)
+
+	BeforeEach(func() {
+		name := fmt.Sprintf("cluster-%d", rand.Int31())
+		ns := "default"
+
+		wp = New(&wordpressv1alpha1.Wordpress{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: ns,
+				Labels:    map[string]string{"app.kubernetes.io/part-of": "test"},
+			},
+			Spec: wordpressv1alpha1.WordpressSpec{
+				Domains: []wordpressv1alpha1.Domain{"test.com"},
+			},
+		})
+		wp.SetDefaults()
+	})
+
+	DescribeTable("Shouldn't generate any init containers, if git and a remote stream is not configured",
+		func(f func() corev1.PodTemplateSpec) {
+			Expect(f().Spec.InitContainers).To(Equal([]corev1.Container{}))
+		},
+		Entry("for web pod", func() corev1.PodTemplateSpec { return wp.WebPodTemplateSpec() }),
+		Entry("for job pod", func() corev1.PodTemplateSpec { return wp.JobPodTemplateSpec() }),
+	)
+
+	DescribeTable("Should generate just a git container, when no remote stream is configure",
+		func(f func() (func() corev1.PodTemplateSpec, *Wordpress)) {
+			podSpec, w := f()
+
+			w.Spec.CodeVolumeSpec = &wordpressv1alpha1.CodeVolumeSpec{
+				GitDir: &wordpressv1alpha1.GitVolumeSource{},
+			}
+			containers := podSpec().Spec.InitContainers
+
+			Expect(len(containers)).To(Equal(1))
+			Expect(containers[0].Name).To(Equal("git"))
+			Expect(containers[0].Image).To(Equal(gitCloneImage))
+		},
+		Entry("for web pod", func() (func() corev1.PodTemplateSpec, *Wordpress) {
+			return wp.WebPodTemplateSpec, wp
+		}),
+		Entry("for job pod", func() (func() corev1.PodTemplateSpec, *Wordpress) {
+			return func() corev1.PodTemplateSpec { return wp.JobPodTemplateSpec("test") }, wp
+		}),
+	)
+
+	DescribeTable("Should generate a git container and a rclone container when gcs is configured",
+		func(f func() (func() corev1.PodTemplateSpec, *Wordpress)) {
+			podSpec, w := f()
+
+			w.Spec.CodeVolumeSpec = &wordpressv1alpha1.CodeVolumeSpec{
+				GitDir: &wordpressv1alpha1.GitVolumeSource{},
+			}
+			w.Spec.MediaVolumeSpec = &wordpressv1alpha1.MediaVolumeSpec{
+				GCSVolumeSource: &wordpressv1alpha1.GCSVolumeSource{Env: []corev1.EnvVar{}},
+			}
+
+			spec := podSpec()
+
+			initContainers := spec.Spec.InitContainers
+			Expect(len(initContainers)).To(Equal(2))
+
+			Expect(initContainers[0].Name).To(Equal("rclone-init-ftp"))
+			Expect(initContainers[0].Image).To(Equal(rcloneImage))
+
+			Expect(initContainers[1].Name).To(Equal("git"))
+			Expect(initContainers[1].Image).To(Equal(gitCloneImage))
+
+			containers := spec.Spec.Containers
+			Expect(len(containers)).To(Equal(3))
+
+			Expect(containers[1].Name).To(Equal("rclone-ftp"))
+			Expect(containers[1].Image).To(Equal(rcloneImage))
+			Expect(containers[1].Args).To(Equal(
+				[]string{"serve", "ftp", "-vvv", "--vfs-cache-max-age", "30s", "--vfs-cache-mode", "full",
+					"--vfs-cache-poll-interval", "0", "--poll-interval", "0", "$(RCLONE_STREAM)/",
+					fmt.Sprintf("--addr=0.0.0.0:%d", mediaFTPPort),
+				}))
+			Expect(containers[1].Env).To(Equal([]corev1.EnvVar{
+				{
+					Name:  "RCLONE_STREAM",
+					Value: "gs:",
+				},
+			}))
+
+			Expect(containers[2].Name).To(Equal("rclone-http"))
+			Expect(containers[2].Image).To(Equal(rcloneImage))
+			Expect(containers[2].Args).To(Equal([]string{
+				"serve", "http", "-vvv", "--dir-cache-time", "0", "$(RCLONE_STREAM)/",
+				fmt.Sprintf("--addr=0.0.0.0:%d", mediaHTTPPort),
+			}))
+			Expect(containers[2].Env).To(Equal([]corev1.EnvVar{
+				{
+					Name:  "RCLONE_STREAM",
+					Value: "gs:",
+				},
+			}))
+		},
+
+		Entry("for web pod", func() (func() corev1.PodTemplateSpec, *Wordpress) {
+			return wp.WebPodTemplateSpec, wp
+		}),
+		Entry("for job pod", func() (func() corev1.PodTemplateSpec, *Wordpress) {
+			return func() corev1.PodTemplateSpec { return wp.JobPodTemplateSpec("test") }, wp
+		}),
+	)
+})


### PR DESCRIPTION
Starts Wordpress with `UPLOADS_FTP_HOST` and `UPLOADS_HTTP_PROXY` that point to newly added rclone containers.

#### Tests
- use `wordpress-chart` to create a new site
- set `bucket`, `project_id` and `google_credentials`
- upload a photo
- upload a pdf
- those files should be served