### PR TITLE
Adapt operator to stack-wordpress changes

### DIFF
--- a/pkg/controller/wordpress/internal/sync/cron.go
+++ b/pkg/controller/wordpress/internal/sync/cron.go
@@ -72,7 +72,8 @@ func NewWPCronSyncer(wp *wordpress.Wordpress, c client.Client, scheme *runtime.S
 
 		hostHeader := fmt.Sprintf("Host: %s", wp.Spec.Domains[0])
 		webPod := fmt.Sprintf("%s.%s.svc", wp.Name, wp.Namespace)
-		url := fmt.Sprintf("http://%s/wp/wp-cron.php?doing_wp_cron&ts=%d", webPod, time.Now().Unix())
+		url := fmt.Sprintf("http://%s:%d/wp/wp-cron.php?doing_wp_cron&ts=%d", webPod, wordpress.WordpressHTTPPort,
+			time.Now().Unix())
 
 		// curl -s -I --max-time 30 -H "Host: <Host>" "http://<site>.<namespace>.svc/wp-cron.php?doing_wp_cron&ts=<now>"
 		cmd := []string{"curl", "-s", "-I", "--max-time", "30", "-H", hostHeader, url}

--- a/pkg/controller/wordpress/internal/sync/cron.go
+++ b/pkg/controller/wordpress/internal/sync/cron.go
@@ -18,15 +18,13 @@ package sync
 
 import (
 	"fmt"
+	"github.com/appscode/mergo"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"time"
-
-	"github.com/appscode/mergo"
 
 	"github.com/presslabs/controller-util/mergo/transformers"
 	"github.com/presslabs/controller-util/syncer"
@@ -72,9 +70,9 @@ func NewWPCronSyncer(wp *wordpress.Wordpress, c client.Client, scheme *runtime.S
 
 		hostHeader := fmt.Sprintf("Host: %s", wp.Spec.Domains[0])
 		svcHostname := fmt.Sprintf("%s.%s.svc", wp.Name, wp.Namespace)
-		url := fmt.Sprintf("http://%s/wp/wp-cron.php?doing_wp_cron&ts=%d", svcHostname, time.Now().Unix())
+		url := fmt.Sprintf("http://%s/wp/wp-cron.php?doing_wp_cron", svcHostname)
 
-		// curl -s -I --max-time 30 -H "Host: <Host>" "http://<site>.<namespace>.svc/wp-cron.php?doing_wp_cron&ts=<now>"
+		// curl -s -I --max-time 30 -H "Host: <Host>" "http://<site>.<namespace>.svc/wp-cron.php?doing_wp_cron"
 		cmd := []string{"curl", "-s", "-I", "--max-time", "30", "-H", hostHeader, url}
 
 		template := corev1.PodTemplateSpec{}

--- a/pkg/controller/wordpress/internal/sync/cron.go
+++ b/pkg/controller/wordpress/internal/sync/cron.go
@@ -71,9 +71,8 @@ func NewWPCronSyncer(wp *wordpress.Wordpress, c client.Client, scheme *runtime.S
 		out.Spec.JobTemplate.Spec.ActiveDeadlineSeconds = &activeDeadlineSeconds
 
 		hostHeader := fmt.Sprintf("Host: %s", wp.Spec.Domains[0])
-		webPod := fmt.Sprintf("%s.%s.svc", wp.Name, wp.Namespace)
-		url := fmt.Sprintf("http://%s:%d/wp/wp-cron.php?doing_wp_cron&ts=%d", webPod, wordpress.WordpressHTTPPort,
-			time.Now().Unix())
+		svcHostname := fmt.Sprintf("%s.%s.svc", wp.Name, wp.Namespace)
+		url := fmt.Sprintf("http://%s/wp/wp-cron.php?doing_wp_cron&ts=%d", svcHostname, time.Now().Unix())
 
 		// curl -s -I --max-time 30 -H "Host: <Host>" "http://<site>.<namespace>.svc/wp-cron.php?doing_wp_cron&ts=<now>"
 		cmd := []string{"curl", "-s", "-I", "--max-time", "30", "-H", hostHeader, url}

--- a/pkg/controller/wordpress/internal/sync/service.go
+++ b/pkg/controller/wordpress/internal/sync/service.go
@@ -31,10 +31,6 @@ import (
 	"github.com/presslabs/wordpress-operator/pkg/internal/wordpress"
 )
 
-const (
-	wordpressHTTPPort = 80
-)
-
 // NewServiceSyncer returns a new sync.Interface for reconciling web Service
 func NewServiceSyncer(wp *wordpress.Wordpress, c client.Client, scheme *runtime.Scheme) syncer.Interface {
 	objLabels := wp.ComponentLabels(wordpress.WordpressDeployment)
@@ -65,7 +61,7 @@ func NewServiceSyncer(wp *wordpress.Wordpress, c client.Client, scheme *runtime.
 
 		out.Spec.Ports[0].Name = "http"
 		out.Spec.Ports[0].Port = int32(80)
-		out.Spec.Ports[0].TargetPort = intstr.FromInt(wordpressHTTPPort)
+		out.Spec.Ports[0].TargetPort = intstr.FromInt(wordpress.WordpressHTTPPort)
 
 		return nil
 	})

--- a/pkg/controller/wordpress/internal/sync/service.go
+++ b/pkg/controller/wordpress/internal/sync/service.go
@@ -61,7 +61,7 @@ func NewServiceSyncer(wp *wordpress.Wordpress, c client.Client, scheme *runtime.
 
 		out.Spec.Ports[0].Name = "http"
 		out.Spec.Ports[0].Port = int32(80)
-		out.Spec.Ports[0].TargetPort = intstr.FromInt(wordpress.WordpressHTTPPort)
+		out.Spec.Ports[0].TargetPort = intstr.FromInt(wordpress.InternalHTTPPort)
 
 		return nil
 	})

--- a/pkg/internal/wordpress/defaults.go
+++ b/pkg/internal/wordpress/defaults.go
@@ -17,10 +17,10 @@ limitations under the License.
 package wordpress
 
 const (
-	defaultTag           = "5.0.3-php72-r74"
+	defaultTag           = "5.1-r62"
 	defaultImage         = "quay.io/presslabs/wordpress-runtime"
 	codeSrcMountPath     = "/var/run/presslabs.org/code/src"
-	defaultCodeMountPath = "/var/www/site/web/wp-content"
+	defaultCodeMountPath = "/var/www/html/wp-content"
 )
 
 // SetDefaults sets Wordpress field defaults

--- a/pkg/internal/wordpress/defaults.go
+++ b/pkg/internal/wordpress/defaults.go
@@ -17,7 +17,7 @@ limitations under the License.
 package wordpress
 
 const (
-	defaultTag           = "5.1-r72"
+	defaultTag           = "5.1-r73"
 	defaultImage         = "quay.io/presslabs/wordpress-runtime"
 	codeSrcMountPath     = "/var/run/presslabs.org/code/src"
 	defaultCodeMountPath = "/var/www/html/wp-content"

--- a/pkg/internal/wordpress/defaults.go
+++ b/pkg/internal/wordpress/defaults.go
@@ -17,7 +17,7 @@ limitations under the License.
 package wordpress
 
 const (
-	defaultTag           = "5.1-r62"
+	defaultTag           = "5.1-r72"
 	defaultImage         = "quay.io/presslabs/wordpress-runtime"
 	codeSrcMountPath     = "/var/run/presslabs.org/code/src"
 	defaultCodeMountPath = "/var/www/html/wp-content"

--- a/pkg/internal/wordpress/pod_template.go
+++ b/pkg/internal/wordpress/pod_template.go
@@ -24,16 +24,16 @@ import (
 )
 
 const (
-	// WordpressHTTPPort represents the internal port used by the runtime container
-	WordpressHTTPPort = 8080
-	gitCloneImage     = "docker.io/library/buildpack-deps:stretch-scm"
-	rcloneImage       = "quay.io/presslabs/rclone@sha256:4436a1e2d471236eafac605b24a66f5f18910b6f9cde505db065506208f73f96"
-	mediaHTTPPort     = 8090
-	mediaFTPPort      = 2121
-	codeVolumeName    = "code"
-	mediaVolumeName   = "media"
-	s3Prefix          = "s3"
-	gcsPrefix         = "gs"
+	// InternalHTTPPort represents the internal port used by the runtime container
+	InternalHTTPPort = 8080
+	gitCloneImage    = "docker.io/library/buildpack-deps:stretch-scm"
+	rcloneImage      = "quay.io/presslabs/rclone@sha256:4436a1e2d471236eafac605b24a66f5f18910b6f9cde505db065506208f73f96"
+	mediaHTTPPort    = 8090
+	mediaFTPPort     = 2121
+	codeVolumeName   = "code"
+	mediaVolumeName  = "media"
+	s3Prefix         = "s3"
+	gcsPrefix        = "gs"
 )
 
 const gitCloneScript = `#!/bin/bash
@@ -372,7 +372,7 @@ func (wp *Wordpress) WebPodTemplateSpec() (out corev1.PodTemplateSpec) {
 			Ports: []corev1.ContainerPort{
 				{
 					Name:          "http",
-					ContainerPort: int32(WordpressHTTPPort),
+					ContainerPort: int32(InternalHTTPPort),
 				},
 			},
 		},

--- a/pkg/internal/wordpress/pod_template.go
+++ b/pkg/internal/wordpress/pod_template.go
@@ -24,10 +24,11 @@ import (
 )
 
 const (
+	// WordpressHTTPPort represents the internal port used by the runtime container
+	WordpressHTTPPort = 8080
 	gitCloneImage     = "docker.io/library/buildpack-deps:stretch-scm"
 	rcloneImage       = "quay.io/presslabs/rclone@sha256:4436a1e2d471236eafac605b24a66f5f18910b6f9cde505db065506208f73f96"
-	wordpressHTTPPort = 80
-	mediaHTTPPort     = 8080
+	mediaHTTPPort     = 8090
 	mediaFTPPort      = 2121
 	codeVolumeName    = "code"
 	mediaVolumeName   = "media"
@@ -371,7 +372,7 @@ func (wp *Wordpress) WebPodTemplateSpec() (out corev1.PodTemplateSpec) {
 			Ports: []corev1.ContainerPort{
 				{
 					Name:          "http",
-					ContainerPort: int32(wordpressHTTPPort),
+					ContainerPort: int32(WordpressHTTPPort),
 				},
 			},
 		},

--- a/pkg/internal/wordpress/pod_template.go
+++ b/pkg/internal/wordpress/pod_template.go
@@ -332,12 +332,12 @@ func (wp *Wordpress) initContainers() []corev1.Container {
 
 	if wp.hasExternalMedia() {
 		// rclone-init-ftp
-		// rclone mkdir gcs:prefix/wp-content/uploads
+		// rclone touch gcs:prefix/wp-content/uploads/.keep
 		// Because of https://bugs.php.net/bug.php?id=77680, we need to create the root directories.
 		// For now, we don't support custom UPLOADS paths, only the default one (wp-content/uploads).
 		// TODO: remove it once the fix is released
 		initFTPCmd := []string{
-			"mkdir", "-vvv", "$(RCLONE_STREAM)/wp-content/uploads",
+			"touch", "-vvv", "$(RCLONE_STREAM)/wp-content/uploads/.keep",
 		}
 
 		containers = append(containers, wp.rcloneContainer("rclone-init-ftp", initFTPCmd))


### PR DESCRIPTION
* runtime http port was changed from `80` -> `8080`
* http upload's proxy port was updated from `8080` -> `8090`
* `defaultCodeMountPath` now follows `bedrock`'s standard

#### Tests
* `make run`
* create a new site using `wordpress-chart`
* it **should** start a new wordpress instance
* try to upload new photos / pdf (with gcs credentials enabled)
* it **should** serve the bucket via gcs