### PR TITLE
Add a readiness and liveness probe for the web pod

### DIFF
--- a/pkg/internal/wordpress/pod_template.go
+++ b/pkg/internal/wordpress/pod_template.go
@@ -19,15 +19,13 @@ package wordpress
 import (
 	"bytes"
 	"fmt"
+	"path"
+	"strings"
 	"text/template"
 
 	corev1 "k8s.io/api/core/v1"
-
-	"path"
-
-	"strings"
-
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/presslabs/wordpress-operator/pkg/cmd/options"
 )
@@ -493,6 +491,25 @@ func (wp *Wordpress) initContainers() []corev1.Container {
 	return containers
 }
 
+func (wp *Wordpress) readinessHandler() corev1.Handler {
+	// If the HTTPGetAction doesn't have any Host parameter it will use pod's IP address as Host.
+	// This is helpful because Wordpress may not be installed and in this case it will redirect to
+	// Spec.Routes[0]. If the same host was used in the initial request as Spec.Routes[0], k8s will follow
+	// the Location header, which may point to an unreachable address, thus making the pod UnHealthy.
+	//
+	// Refs:
+	//	* https://github.com/kubernetes/kubernetes/pull/75416
+	//	* https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
+	//	  Any code greater than or equal to 200 and less than 400 indicates success.
+
+	return corev1.Handler{
+		HTTPGet: &corev1.HTTPGetAction{
+			Path: "/",
+			Port: intstr.FromInt(InternalHTTPPort),
+		},
+	}
+}
+
 // WebPodTemplateSpec generates a pod template spec suitable for use in Wordpress deployment
 // nolint: funlen
 func (wp *Wordpress) WebPodTemplateSpec() (out corev1.PodTemplateSpec) {
@@ -539,6 +556,14 @@ func (wp *Wordpress) WebPodTemplateSpec() (out corev1.PodTemplateSpec) {
 						"if test -n \"$PRE_STOP_SCRIPTS\" && command -v run-parts >/dev/null 2>&1 && test -d \"$PRE_STOP_SCRIPTS\"  ; then run-parts --exit-on-error -v \"$PRE_STOP_SCRIPTS\" ; fi", // nolint: lll
 					},
 				},
+			},
+			ReadinessProbe: &corev1.Probe{
+				Handler:             wp.readinessHandler(),
+				InitialDelaySeconds: 10,
+				TimeoutSeconds:      30,
+				PeriodSeconds:       5,
+				SuccessThreshold:    1,
+				FailureThreshold:    3,
 			},
 		},
 	}


### PR DESCRIPTION
⚠️ This PR works only for k8s 1.14+

Adds a readiness and a liveness probe for the web pod.

The readiness probe pings the web pod, using the pod's IP and it shouldn't follow the redirect to `Spec.Domains[0]`. 
The liveness probe ping the php-fpm status.