### PR TITLE
Add support for blackfire in operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ spec:
   volumes: []
   # extra volume mounts for the Wordpress container
   volumeMounts: []
-  # extra env variables for the Wordpress container
+  # extra env variables for the Wordpress container or to enable certain features
   env:
     - name: WORDPRESS_DB_HOST
       value: mysite-mysql
@@ -87,6 +87,10 @@ spec:
       valueFrom:
         secretKeyRef: mysite-mysql
         key: PASSWORD
+    - name: BLACKFIRE_SERVER_ID
+      value: your-blackfire-server-id
+    - name: BLACKFIRE_SERVER_TOKEN
+      value: your-blackfire-server-token
   envFrom: []
 
   # secret containg HTTPS certificate


### PR DESCRIPTION
Enable [blackfire](https://blackfire.io/) probe container.

In order to debug performance issues, you can use a PHP profiler, like blackfire. You can find out more details on [docs](https://blackfire.io/docs/introduction).

#### Tests
* add `BLACKFIRE_SERVER_ID` to the stack environment
* it **shouldn't** create a new blackfire container 
* add `BLACKFIRE_SERVER_TOKEN` to the stack environment
* it **should** create a new blackfire container
* install the blackfire extension
* you **should** be able to create profiles and see them in blackfire's dashboard