### PR TITLE
Fix #43 by adding origin to checkout

### DIFF
--- a/pkg/internal/wordpress/pod_template.go
+++ b/pkg/internal/wordpress/pod_template.go
@@ -60,7 +60,7 @@ find "$SRC_DIR" -maxdepth 1 -mindepth 1 -print0 | xargs -0 /bin/rm -rf
 set -x
 git clone "$GIT_CLONE_URL" "$SRC_DIR"
 cd "$SRC_DIR"
-git checkout -B "$GIT_CLONE_REF" origin/"$GIT_CLONE_REF"
+git checkout -B "$GIT_CLONE_REF" "origin/$GIT_CLONE_REF"
 `
 
 var (

--- a/pkg/internal/wordpress/pod_template.go
+++ b/pkg/internal/wordpress/pod_template.go
@@ -60,7 +60,7 @@ find "$SRC_DIR" -maxdepth 1 -mindepth 1 -print0 | xargs -0 /bin/rm -rf
 set -x
 git clone "$GIT_CLONE_URL" "$SRC_DIR"
 cd "$SRC_DIR"
-git checkout -B "$GIT_CLONE_REF" "$GIT_CLONE_REF"
+git checkout -B "$GIT_CLONE_REF" origin/"$GIT_CLONE_REF"
 `
 
 var (


### PR DESCRIPTION
Checkout only works on local branches or on remote ones when the remote is given. By adding origin before the branch the bug is fixed.