### PR TITLE
update(chart) Update deployment version of the Chart

### DIFF
--- a/deploy/charts/wordpress-operator/templates/deployment.yaml
+++ b/deploy/charts/wordpress-operator/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "wordpress-operator.fullname" . }}


### PR DESCRIPTION
apps/v1beta2 is removed on newest Kubernetes versions

Signed-off-by: Pierre Péronnet <pierre.peronnet@ovhcloud.com>